### PR TITLE
feat: [BACK] 풍선에 색깔 추가

### DIFF
--- a/backend/src/main/java/com/musicinaballoon/balloon/annotation/ColorCode.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/annotation/ColorCode.java
@@ -1,0 +1,19 @@
+package com.musicinaballoon.balloon.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ColorCodeValidator.class)
+public @interface ColorCode {
+    String message() default "Color code";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/musicinaballoon/balloon/annotation/ColorCodeValidator.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/annotation/ColorCodeValidator.java
@@ -1,0 +1,16 @@
+package com.musicinaballoon.balloon.annotation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class ColorCodeValidator implements ConstraintValidator<ColorCode, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return value.matches("^#[A-Fa-f0-9]{6}$");
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/balloon/application/BalloonService.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/application/BalloonService.java
@@ -1,11 +1,15 @@
 package com.musicinaballoon.balloon.application;
 
+import static com.musicinaballoon.music.domain.StreamingMusicType.SPOTIFY_MUSIC;
+import static com.musicinaballoon.music.domain.StreamingMusicType.YOUTUBE_MUSIC;
+
 import com.musicinaballoon.balloon.domain.Balloon;
+import com.musicinaballoon.balloon.domain.Balloon.BalloonBuilder;
 import com.musicinaballoon.balloon.repository.BalloonRepository;
 import com.musicinaballoon.common.exception.ErrorCode;
 import com.musicinaballoon.common.exception.NotFoundException;
 import com.musicinaballoon.music.domain.SpotifyMusic;
-import com.musicinaballoon.music.domain.StreamingMusicType;
+import com.musicinaballoon.music.domain.StreamingMusic;
 import com.musicinaballoon.music.domain.YoutubeMusic;
 import com.musicinaballoon.user.domain.User;
 import java.math.BigDecimal;
@@ -26,30 +30,24 @@ public class BalloonService {
         this.balloonListPageSize = balloonListPageSize;
     }
 
-    public Balloon createYoutubeMusicBalloon(YoutubeMusic youtubeMusic, BigDecimal latitude, BigDecimal longitude, User creator
-            , String message) {
-        Balloon balloon = Balloon.builder()
-                .uploadedStreamingMusicType(StreamingMusicType.YOUTUBE_MUSIC)
-                .youtubeMusic(youtubeMusic)
+    public Balloon createBalloon(StreamingMusic streamingMusic, BigDecimal latitude, BigDecimal longitude, User creator
+            , String message, String colorCode) {
+        BalloonBuilder balloonBuilder = Balloon.builder()
                 .creator(creator)
                 .baseLatitude(latitude)
                 .baseLongitude(longitude)
                 .message(message)
-                .build();
-        return balloonRepository.save(balloon);
-    }
+                .colorCode(colorCode);
 
-    public Balloon createSpotifyMusicBalloon(SpotifyMusic spotifyMusic, BigDecimal latitude, BigDecimal longitude, User creator
-            , String message) {
-        Balloon balloon = Balloon.builder()
-                .uploadedStreamingMusicType(StreamingMusicType.SPOTIFY_MUSIC)
-                .spotifyMusic(spotifyMusic)
-                .creator(creator)
-                .baseLatitude(latitude)
-                .baseLongitude(longitude)
-                .message(message)
-                .build();
-        return balloonRepository.save(balloon);
+        return balloonRepository.save(
+                switch (streamingMusic.getStreamingMusicType()) {
+                    case YOUTUBE_MUSIC -> balloonBuilder.uploadedStreamingMusicType(YOUTUBE_MUSIC)
+                            .youtubeMusic((YoutubeMusic) streamingMusic)
+                            .build();
+                    case SPOTIFY_MUSIC -> balloonBuilder.uploadedStreamingMusicType(SPOTIFY_MUSIC)
+                            .spotifyMusic((SpotifyMusic) streamingMusic)
+                            .build();
+                });
     }
 
     public Balloon getBalloon(Long balloonId) {

--- a/backend/src/main/java/com/musicinaballoon/balloon/application/request/CreateBalloonRequest.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/application/request/CreateBalloonRequest.java
@@ -1,5 +1,6 @@
 package com.musicinaballoon.balloon.application.request;
 
+import com.musicinaballoon.balloon.annotation.ColorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotBlank;
@@ -26,6 +27,11 @@ public record CreateBalloonRequest(
         @NotBlank
         @Size(max = 255)
         @Schema(example = "My favorite music 🎧")
-        String message
+        String message,
+
+        @NotNull
+        @ColorCode
+        @Schema(example = "#F06292")
+        String colorCode
 ) {
 }

--- a/backend/src/main/java/com/musicinaballoon/balloon/application/response/BalloonListItemResponse.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/application/response/BalloonListItemResponse.java
@@ -12,6 +12,8 @@ public record BalloonListItemResponse(
 
         @Schema(example = "Super Shy")
         String title,
+        @Schema(example = "#F06292")
+        String colorCode,
 
         @Schema(example = "29.9794559943191")
         BigDecimal baseLon,
@@ -30,6 +32,7 @@ public record BalloonListItemResponse(
         return BalloonListItemResponse.builder()
                 .id(balloon.getId())
                 .title(balloon.getMusicTitle())
+                .colorCode(balloon.getColorCode())
 
                 .baseLat(balloon.getBaseLatitude())
                 .baseLon(balloon.getBaseLongitude())

--- a/backend/src/main/java/com/musicinaballoon/balloon/application/response/BalloonResponse.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/application/response/BalloonResponse.java
@@ -16,6 +16,8 @@ public record BalloonResponse(
         String title,
         @Schema(example = "I love this song 🥰")
         String message,
+        @Schema(example = "#F06292")
+        String colorCode,
 
         @Schema(example = "youtube")
         String uploadedStreamingMusicType,
@@ -45,6 +47,7 @@ public record BalloonResponse(
                 .id(balloon.getId())
                 .title(balloon.getMusicTitle())
                 .message(balloon.getMessage())
+                .colorCode(balloon.getColorCode())
 
                 .uploadedStreamingMusicType(balloon.getUploadedStreamingMusicType().name())
                 .albumImageUrl(balloon.getAlbumImageUrl())

--- a/backend/src/main/java/com/musicinaballoon/balloon/domain/Balloon.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/domain/Balloon.java
@@ -38,6 +38,12 @@ public class Balloon extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "message", length = 255, nullable = false)
+    private String message;
+
+    @Column(name = "color_code", nullable = false)
+    private String colorCode;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "uploaded_streaming_music_type", nullable = false)
     private StreamingMusicType uploadedStreamingMusicType;
@@ -60,21 +66,19 @@ public class Balloon extends BaseEntity {
     @Column(name = "base_longitude", precision = 16, scale = 13, nullable = false)
     private BigDecimal baseLongitude;
 
-    @Column(name = "message", length = 255, nullable = false)
-    private String message;
-
     @Column(name = "based_at", nullable = false)
     private ZonedDateTime basedAt;
 
     @Builder
-    public Balloon(
+    protected Balloon(
             @NonNull StreamingMusicType uploadedStreamingMusicType,
             YoutubeMusic youtubeMusic,
             SpotifyMusic spotifyMusic,
             @NonNull User creator,
             @NonNull BigDecimal baseLatitude,
             @NonNull BigDecimal baseLongitude,
-            @NonNull String message
+            @NonNull String message,
+            @NonNull String colorCode
     ) {
         this.uploadedStreamingMusicType = uploadedStreamingMusicType;
         this.youtubeMusic = youtubeMusic;
@@ -83,6 +87,7 @@ public class Balloon extends BaseEntity {
         this.baseLatitude = baseLatitude;
         this.baseLongitude = baseLongitude;
         this.message = message;
+        this.colorCode = colorCode;
     }
 
     public Geolocation getCurrentGeolocation(Wave wave) {

--- a/backend/src/test/java/com/musicinaballoon/balloon/application/BalloonServiceTest.java
+++ b/backend/src/test/java/com/musicinaballoon/balloon/application/BalloonServiceTest.java
@@ -1,5 +1,6 @@
 package com.musicinaballoon.balloon.application;
 
+import static com.musicinaballoon.fixture.BalloonFixture.DEFAULT_COLOR_CODE;
 import static com.musicinaballoon.fixture.BalloonFixture.DEFAULT_MESSAGE;
 import static com.musicinaballoon.fixture.BalloonFixture.youtubeMusicBalloonBuilder;
 import static com.musicinaballoon.fixture.MusicFixture.spotifyMusicBuilder;
@@ -50,7 +51,7 @@ class BalloonServiceTest {
 
     @DisplayName("유튜브 뮤직으로 풍선을 생성한다")
     @Test
-    void createYoutubeMusicBalloon() {
+    void createBalloon_ValidInputsWithYoutubeMusic_ReturnsBalloon() {
         // given
         YoutubeMusic youtubeMusic = youtubeMusicBuilder().build();
         User user = userBuilder().build();
@@ -58,8 +59,8 @@ class BalloonServiceTest {
         given(balloonRepository.save(any(Balloon.class))).will(returnsFirstArg());
 
         // when
-        Balloon created = balloonService.createYoutubeMusicBalloon(youtubeMusic, PYRAMID_OF_KHUFU_LATITUDE,
-                PYRAMID_OF_KHUFU_LONGITUDE, user, DEFAULT_MESSAGE);
+        Balloon created = balloonService.createBalloon(youtubeMusic, PYRAMID_OF_KHUFU_LATITUDE,
+                PYRAMID_OF_KHUFU_LONGITUDE, user, DEFAULT_MESSAGE, DEFAULT_COLOR_CODE);
 
         // then
         assertSoftly(
@@ -69,13 +70,15 @@ class BalloonServiceTest {
                     softly.assertThat(created.getBaseLongitude()).isEqualTo(PYRAMID_OF_KHUFU_LONGITUDE);
                     softly.assertThat(created.getBaseLatitude()).isEqualTo(PYRAMID_OF_KHUFU_LATITUDE);
                     softly.assertThat(created.getCreator()).isEqualTo(user);
+                    softly.assertThat(created.getColorCode()).isEqualTo(DEFAULT_COLOR_CODE);
+                    softly.assertThat(created.getMessage()).isEqualTo(DEFAULT_MESSAGE);
                 }
         );
     }
 
     @DisplayName("스포티파이 뮤직으로 풍선을 생성한다")
     @Test
-    void createSpotifyMusicBalloon() {
+    void createBalloon_ValidInputsWithSpotifyMusic_ReturnsBalloon() {
         // given
         SpotifyMusic spotifyMusic = spotifyMusicBuilder().build();
         User user = userBuilder().build();
@@ -83,9 +86,8 @@ class BalloonServiceTest {
         given(balloonRepository.save(any(Balloon.class))).will(returnsFirstArg());
 
         // when
-        Balloon created = balloonService.createSpotifyMusicBalloon(spotifyMusic, PYRAMID_OF_KHUFU_LATITUDE,
-                PYRAMID_OF_KHUFU_LONGITUDE, user, DEFAULT_MESSAGE
-        );
+        Balloon created = balloonService.createBalloon(spotifyMusic, PYRAMID_OF_KHUFU_LATITUDE,
+                PYRAMID_OF_KHUFU_LONGITUDE, user, DEFAULT_MESSAGE, DEFAULT_COLOR_CODE);
 
         // then
         assertSoftly(
@@ -95,6 +97,8 @@ class BalloonServiceTest {
                     softly.assertThat(created.getBaseLongitude()).isEqualTo(PYRAMID_OF_KHUFU_LONGITUDE);
                     softly.assertThat(created.getBaseLatitude()).isEqualTo(PYRAMID_OF_KHUFU_LATITUDE);
                     softly.assertThat(created.getCreator()).isEqualTo(user);
+                    softly.assertThat(created.getColorCode()).isEqualTo(DEFAULT_COLOR_CODE);
+                    softly.assertThat(created.getMessage()).isEqualTo(DEFAULT_MESSAGE);
                 }
         );
     }

--- a/backend/src/test/java/com/musicinaballoon/balloon/presentation/PostBalloonTest.java
+++ b/backend/src/test/java/com/musicinaballoon/balloon/presentation/PostBalloonTest.java
@@ -1,5 +1,6 @@
 package com.musicinaballoon.balloon.presentation;
 
+import static com.musicinaballoon.fixture.BalloonFixture.DEFAULT_COLOR_CODE;
 import static com.musicinaballoon.fixture.BalloonFixture.DEFAULT_MESSAGE;
 import static com.musicinaballoon.fixture.MusicFixture.SPOTIFY_MUSIC_SUPER_SHY_TITLE;
 import static com.musicinaballoon.fixture.MusicFixture.SPOTIFY_MUSIC_SUPER_SHY_URL;
@@ -35,10 +36,10 @@ public class PostBalloonTest extends BalloonControllerTest {
     }
 
     @Test
-    @DisplayName("유튜브 음악 URL로 풍선을 생성한다")
-    void createBalloonByYoutubeMusicUrl() {
+    @DisplayName("유튜브 음악 URL 의 유효한 요청은 풍선을 응답한다")
+    void postBalloon_ValidRequestWithYoutubeMusicUrl_ResponsesBalloon() {
         CreateBalloonRequest request = new CreateBalloonRequest(YOUTUBE_MUSIC_SUPER_SHY_URL, PYRAMID_OF_KHUFU_LATITUDE,
-                PYRAMID_OF_KHUFU_LONGITUDE, DEFAULT_MESSAGE);
+                PYRAMID_OF_KHUFU_LONGITUDE, DEFAULT_MESSAGE, DEFAULT_COLOR_CODE);
 
         ExtractableResponse<Response> response = postBalloon(request);
         BalloonResponse balloonResponse = response.as(BalloonResponse.class);
@@ -51,15 +52,16 @@ public class PostBalloonTest extends BalloonControllerTest {
                     softly.assertThat(balloonResponse.uploadedStreamingMusicType())
                             .isEqualTo(StreamingMusicType.YOUTUBE_MUSIC.name());
                     softly.assertThat(balloonResponse.albumImageUrl()).isNotNull();
+                    softly.assertThat(balloonResponse.colorCode()).isEqualTo(DEFAULT_COLOR_CODE);
                 }
         );
     }
 
     @Test
-    @DisplayName("스포티파이 음악 URL로 풍선을 생성한다")
-    void createBalloonBySpotifyMusicUrl() {
+    @DisplayName("스포티파이 음악 URL 의 유효한 요청은 풍선을 응답한다")
+    void postBalloon_ValidRequestWithSpotifyMusicUrl_ResponsesBalloon() {
         CreateBalloonRequest request = new CreateBalloonRequest(SPOTIFY_MUSIC_SUPER_SHY_URL, PYRAMID_OF_KHUFU_LATITUDE,
-                PYRAMID_OF_KHUFU_LONGITUDE, DEFAULT_MESSAGE);
+                PYRAMID_OF_KHUFU_LONGITUDE, DEFAULT_MESSAGE, DEFAULT_COLOR_CODE);
 
         ExtractableResponse<Response> response = postBalloon(request);
         BalloonResponse balloonResponse = response.as(BalloonResponse.class);
@@ -72,6 +74,7 @@ public class PostBalloonTest extends BalloonControllerTest {
                     softly.assertThat(balloonResponse.uploadedStreamingMusicType())
                             .isEqualTo(StreamingMusicType.SPOTIFY_MUSIC.name());
                     softly.assertThat(balloonResponse.albumImageUrl()).isNotNull();
+                    softly.assertThat(balloonResponse.colorCode()).isEqualTo(DEFAULT_COLOR_CODE);
                 }
         );
     }

--- a/backend/src/test/java/com/musicinaballoon/fixture/BalloonFixture.java
+++ b/backend/src/test/java/com/musicinaballoon/fixture/BalloonFixture.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 public final class BalloonFixture {
 
     public static final String DEFAULT_MESSAGE = "노래 투하!";
+    public static final String DEFAULT_COLOR_CODE = "#F06292";
 
     public static final BigDecimal DEFAULT_BASE_LATITUDE = PYRAMID_OF_KHUFU_LATITUDE;
     public static final BigDecimal DEFAULT_BASE_LONGITUDE = PYRAMID_OF_KHUFU_LONGITUDE;
@@ -24,6 +25,7 @@ public final class BalloonFixture {
                 .creator(creator)
                 .baseLatitude(DEFAULT_BASE_LATITUDE)
                 .baseLongitude(DEFAULT_BASE_LONGITUDE)
+                .colorCode(DEFAULT_COLOR_CODE)
                 .message(DEFAULT_MESSAGE);
     }
 }


### PR DESCRIPTION
## 변경사항
- Balloon 엔티티는 colorCode 필드를 갖습니다.
- POST /balloon 는 바디에 풍선의 색을 요구합니다.
- GET /balloon/{balloonId} 에서 풍선의 색을 응답합니다.
- GET /balloon/list 에서 풍선의 색을 응답합니다.