### PR TITLE
feat: [BACK] 리엑션 알림 구독 및 알림 보내기 기능 구현

### DIFF
--- a/backend/src/main/java/com/musicinaballoon/balloon/application/BalloonFacade.java
+++ b/backend/src/main/java/com/musicinaballoon/balloon/application/BalloonFacade.java
@@ -51,24 +51,25 @@ public class BalloonFacade {
     }
 
     public void reactBalloon(Long balloonId, ReactBalloonRequest request, Long userId) {
-        User user = userService.getUser(userId);
-
         if (balloonReactionService.existsBalloonReaction(balloonId, userId)) {
             BalloonReaction balloonReaction = balloonReactionService.getBalloonReaction(balloonId, userId);
             balloonReaction.setType(request.balloonReactionType());
-            notifyReaction(user, balloonReaction);
+
+            notifyReaction(userId, balloonReaction);
         } else {
             balloonPickService.validatePicked(balloonId, userId);
             Balloon balloon = balloonService.getBalloon(balloonId);
 
+            User user = userService.getUser(userId);
             BalloonReaction balloonReaction = balloonReactionService.createBalloonReaction(balloon, user,
                     request.balloonReactionType());
-            notifyReaction(user, balloonReaction);
+
+            notifyReaction(userId, balloonReaction);
         }
     }
 
-    private void notifyReaction(User receiver, BalloonReaction balloonReaction) {
-        reactionNotificationFacade.sendNotification(receiver, balloonReaction);
+    private void notifyReaction(Long receiverId, BalloonReaction balloonReaction) {
+        reactionNotificationFacade.sendNotification(receiverId, balloonReaction);
     }
 
     public void deleteBalloonReaction(Long balloonId, Long userId) {

--- a/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
@@ -50,16 +50,19 @@ public class ReactionNotificationFacade {
 
     public SseEmitter subscribe(Long userId, String lastEventId) {
         userService.validateUserExisted(userId);
-        ZonedDateTime lastReactionNotificationCreatedAt = parseLastReactionNotificationCreatedAt(lastEventId);
 
         SseEmitter sseEmitter = sseEmitterService.createSseEmitter(userId);
         sendDummyEvent(sseEmitter);
 
-        List<ReactionNotification> lostNotifications = reactionNotificationService.getLostNotifications(userId,
-                lastReactionNotificationCreatedAt);
+        if (!lastEventId.isEmpty()) {
+            ZonedDateTime lastReactionNotificationCreatedAt = parseLastReactionNotificationCreatedAt(lastEventId);
 
-        for (ReactionNotification lostNotification : lostNotifications) {
-            sendEvent(sseEmitter, lostNotification);
+            List<ReactionNotification> lostNotifications = reactionNotificationService.getLostNotifications(userId,
+                    lastReactionNotificationCreatedAt);
+
+            for (ReactionNotification lostNotification : lostNotifications) {
+                sendEvent(sseEmitter, lostNotification);
+            }
         }
 
         return sseEmitter;

--- a/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
@@ -1,0 +1,77 @@
+package com.musicinaballoon.notification.application;
+
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.notification.application.response.ReactionNotificationResponse;
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import com.musicinaballoon.user.application.UserService;
+import com.musicinaballoon.user.domain.User;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+public class ReactionNotificationFacade {
+
+    private final SseEmitterService sseEmitterService;
+    private final ReactionNotificationService reactionNotificationService;
+    private final UserService userService;
+
+    private static String makeEventId(ReactionNotification notification) {
+        return notification.getCreatedAt().toString();
+    }
+
+    private static ZonedDateTime parseLastReactionNotificationCreatedAt(String lastEventId) {
+        return ZonedDateTime.parse(lastEventId);
+    }
+
+    private static void sendDummyEvent(SseEmitter sseEmitter) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .id("0")
+                    .name("Dummy")
+                    .data("Dummy message"));
+        } catch (IOException e) {
+            sseEmitter.complete();
+        }
+    }
+
+    private static void sendEvent(SseEmitter sseEmitter, ReactionNotification reactionNotification) {
+        try {
+            sseEmitter.send(SseEmitter.event()
+                    .id(makeEventId(reactionNotification))
+                    .name("Reaction-Notification")
+                    .data(ReactionNotificationResponse.from(reactionNotification)));
+        } catch (IOException e) {
+            sseEmitter.complete();
+        }
+    }
+
+    public SseEmitter subscribe(Long userId, String lastEventId) {
+        userService.validateUserExisted(userId);
+        ZonedDateTime lastReactionNotificationCreatedAt = parseLastReactionNotificationCreatedAt(lastEventId);
+
+        SseEmitter sseEmitter = sseEmitterService.createSseEmitter(userId);
+        sendDummyEvent(sseEmitter);
+
+        List<ReactionNotification> lostNotifications = reactionNotificationService.getLostNotifications(userId,
+                lastReactionNotificationCreatedAt);
+
+        for (ReactionNotification lostNotification : lostNotifications) {
+            sendEvent(sseEmitter, lostNotification);
+        }
+
+        return sseEmitter;
+    }
+
+    public void sendNotification(User receiver, BalloonReaction balloonReaction) {
+        ReactionNotification reactionNotification = reactionNotificationService.createReactionNotification(receiver,
+                balloonReaction);
+
+        if (sseEmitterService.existsEmitter(receiver.getId())) {
+            SseEmitter sseEmitter = sseEmitterService.getSseEmitter(receiver.getId());
+            sendEvent(sseEmitter, reactionNotification);
+        }
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
@@ -76,7 +76,7 @@ public class ReactionNotificationFacade {
                 balloonReaction);
 
         if (sseEmitterService.existsEmitter(receiverId)) {
-            SseEmitter sseEmitter = sseEmitterService.getSseEmitter(receiver.getId());
+            SseEmitter sseEmitter = sseEmitterService.getSseEmitter(receiverId);
             sendEvent(sseEmitter, reactionNotification);
         }
     }

--- a/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
@@ -68,11 +68,12 @@ public class ReactionNotificationFacade {
         return sseEmitter;
     }
 
-    public void sendNotification(User receiver, BalloonReaction balloonReaction) {
+    public void sendNotification(Long receiverId, BalloonReaction balloonReaction) {
+        User receiver = userService.getUser(receiverId);
         ReactionNotification reactionNotification = reactionNotificationService.createReactionNotification(receiver,
                 balloonReaction);
 
-        if (sseEmitterService.existsEmitter(receiver.getId())) {
+        if (sseEmitterService.existsEmitter(receiverId)) {
             SseEmitter sseEmitter = sseEmitterService.getSseEmitter(receiver.getId());
             sendEvent(sseEmitter, reactionNotification);
         }

--- a/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationFacade.java
@@ -9,8 +9,10 @@ import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Service
 @RequiredArgsConstructor
 public class ReactionNotificationFacade {
 

--- a/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationService.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/ReactionNotificationService.java
@@ -1,0 +1,29 @@
+package com.musicinaballoon.notification.application;
+
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import com.musicinaballoon.notification.repository.ReactionNotificationRepository;
+import com.musicinaballoon.user.domain.User;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionNotificationService {
+
+    private final ReactionNotificationRepository reactionNotificationRepository;
+
+    public ReactionNotification createReactionNotification(User receiver, BalloonReaction balloonReaction) {
+        return reactionNotificationRepository.save(ReactionNotification.builder()
+                .receiver(receiver)
+                .balloonReaction(balloonReaction)
+                .build());
+    }
+
+    public List<ReactionNotification> getLostNotifications(Long receiverId, ZonedDateTime lastReactionNotificationCreatedAt) {
+        return reactionNotificationRepository.findByReceiverIdAndCreatedAtGreaterThanOrderByCreatedAtAsc(receiverId,
+                lastReactionNotificationCreatedAt);
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/application/SseEmitterService.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/SseEmitterService.java
@@ -1,0 +1,31 @@
+package com.musicinaballoon.notification.application;
+
+import com.musicinaballoon.notification.repository.EmitterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+public class SseEmitterService {
+
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    private final EmitterRepository emitterRepository;
+
+    public SseEmitter createSseEmitter(final Long receiverId) {
+        SseEmitter emitter = emitterRepository.save(receiverId, new SseEmitter(DEFAULT_TIMEOUT));
+
+        emitter.onCompletion(() -> emitterRepository.deleteByReceiverId(receiverId));
+        emitter.onTimeout(() -> emitterRepository.deleteByReceiverId(receiverId));
+
+        return emitter;
+    }
+
+    public boolean existsEmitter(Long receiverId) {
+        return emitterRepository.existsByReceiverId(receiverId);
+    }
+
+    public SseEmitter getSseEmitter(Long receiverId) {
+        return emitterRepository.findByReceiverId(receiverId);
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/application/response/ReactionNotificationResponse.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/application/response/ReactionNotificationResponse.java
@@ -1,0 +1,29 @@
+package com.musicinaballoon.notification.application.response;
+
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.balloon.domain.BalloonReactionType;
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import java.time.ZonedDateTime;
+import lombok.Builder;
+
+@Builder
+public record ReactionNotificationResponse(
+        Long id,
+        Long receiverId,
+        Long balloonId,
+        BalloonReactionType reactionType,
+        ZonedDateTime createdAt
+) {
+
+    public static ReactionNotificationResponse from(ReactionNotification reactionNotification) {
+        BalloonReaction balloonReaction = reactionNotification.getBalloonReaction();
+
+        return ReactionNotificationResponse.builder()
+                .id(reactionNotification.getId())
+                .receiverId(reactionNotification.getReceiver().getId())
+                .balloonId(balloonReaction.getBalloon().getId())
+                .reactionType(balloonReaction.getType())
+                .createdAt(reactionNotification.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/domain/ReactionNotification.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/domain/ReactionNotification.java
@@ -1,0 +1,43 @@
+package com.musicinaballoon.notification.domain;
+
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.common.domain.BaseEntity;
+import com.musicinaballoon.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+@Getter
+@Entity(name = "notify")
+@NoArgsConstructor
+public class ReactionNotification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "balloon_reaction", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private BalloonReaction balloonReaction;
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User receiver;
+
+    @Builder
+    public ReactionNotification(@NonNull BalloonReaction balloonReaction, @NonNull User receiver) {
+        this.balloonReaction = balloonReaction;
+        this.receiver = receiver;
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/presentation/ReactionNotificationController.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/presentation/ReactionNotificationController.java
@@ -1,0 +1,26 @@
+package com.musicinaballoon.notification.presentation;
+
+import com.musicinaballoon.auth.presentation.UserId;
+import com.musicinaballoon.notification.application.ReactionNotificationFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class ReactionNotificationController {
+
+    private final ReactionNotificationFacade reactionNotificationFacade;
+
+    @GetMapping(value = "/notification/reaction/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(@UserId Long userId,
+            @RequestHeader(value = "Last-Event-ID", required = false,
+                    defaultValue = "") String lastEventId) {
+        SseEmitter emitter = reactionNotificationFacade.subscribe(userId, lastEventId);
+        return ResponseEntity.ok(emitter);
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/repository/EmitterRepository.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/repository/EmitterRepository.java
@@ -1,0 +1,14 @@
+package com.musicinaballoon.notification.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface EmitterRepository {
+
+    SseEmitter save(Long receiverId, SseEmitter sseEmitter);
+
+    boolean existsByReceiverId(Long receiverId);
+
+    SseEmitter findByReceiverId(Long receiverId);
+
+    void deleteByReceiverId(Long receiverId);
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/repository/EmitterRepositoryImpl.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.musicinaballoon.notification.repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(Long receiverId, SseEmitter sseEmitter) {
+        emitters.put(receiverId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public boolean existsByReceiverId(Long receiverId) {
+        return emitters.containsKey(receiverId);
+    }
+
+    @Override
+    public SseEmitter findByReceiverId(Long receiverId) {
+        return emitters.get(receiverId);
+    }
+
+    @Override
+    public void deleteByReceiverId(Long receiverId) {
+        emitters.remove(receiverId);
+    }
+}

--- a/backend/src/main/java/com/musicinaballoon/notification/repository/ReactionNotificationRepository.java
+++ b/backend/src/main/java/com/musicinaballoon/notification/repository/ReactionNotificationRepository.java
@@ -1,0 +1,11 @@
+package com.musicinaballoon.notification.repository;
+
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReactionNotificationRepository extends JpaRepository<ReactionNotification, Long> {
+    List<ReactionNotification> findByReceiverIdAndCreatedAtGreaterThanOrderByCreatedAtAsc(Long receiverId,
+            ZonedDateTime createdAt);
+}

--- a/backend/src/main/java/com/musicinaballoon/user/application/UserService.java
+++ b/backend/src/main/java/com/musicinaballoon/user/application/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
     }
 
     public void validateUserExisted(Long userId) {
-        if (userRepository.existsById(userId)) {
+        if (!userRepository.existsById(userId)) {
             throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
         }
     }

--- a/backend/src/main/java/com/musicinaballoon/user/application/UserService.java
+++ b/backend/src/main/java/com/musicinaballoon/user/application/UserService.java
@@ -2,6 +2,7 @@ package com.musicinaballoon.user.application;
 
 import com.musicinaballoon.common.exception.BadRequestException;
 import com.musicinaballoon.common.exception.ErrorCode;
+import com.musicinaballoon.common.exception.NotFoundException;
 import com.musicinaballoon.user.domain.User;
 import com.musicinaballoon.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,11 @@ public class UserService {
     public User getUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_USER_ID));
+    }
+
+    public void validateUserExisted(Long userId) {
+        if (userRepository.existsById(userId)) {
+            throw new NotFoundException(ErrorCode.USER_NOT_FOUND);
+        }
     }
 }

--- a/backend/src/test/java/com/musicinaballoon/balloon/presentation/BalloonControllerTest.java
+++ b/backend/src/test/java/com/musicinaballoon/balloon/presentation/BalloonControllerTest.java
@@ -9,7 +9,6 @@ import com.musicinaballoon.IntegrationTest;
 import com.musicinaballoon.balloon.domain.Balloon;
 import com.musicinaballoon.balloon.domain.BalloonPicked;
 import com.musicinaballoon.balloon.domain.BalloonReaction;
-import com.musicinaballoon.balloon.domain.BalloonReactionType;
 import com.musicinaballoon.balloon.repository.BalloonPickedRepository;
 import com.musicinaballoon.balloon.repository.BalloonReactionRepository;
 import com.musicinaballoon.balloon.repository.BalloonRepository;
@@ -44,6 +43,6 @@ abstract class BalloonControllerTest extends IntegrationTest {
     }
 
     protected BalloonReaction createBalloonReaction(Balloon balloon) {
-        return balloonReactionRepository.save(balloonReactionBuilder(balloon, defaultUser, BalloonReactionType.BALLOON).build());
+        return balloonReactionRepository.save(balloonReactionBuilder(balloon, defaultUser).build());
     }
 }

--- a/backend/src/test/java/com/musicinaballoon/fixture/BalloonReactionFixture.java
+++ b/backend/src/test/java/com/musicinaballoon/fixture/BalloonReactionFixture.java
@@ -8,10 +8,12 @@ import com.musicinaballoon.user.domain.User;
 
 public final class BalloonReactionFixture {
 
-    public static BalloonReactionBuilder balloonReactionBuilder(Balloon balloon, User user, BalloonReactionType type) {
+    public final static BalloonReactionType DEFAULT_BALLOON_REACTION_TYPE = BalloonReactionType.BALLOON;
+
+    public static BalloonReactionBuilder balloonReactionBuilder(Balloon balloon, User user) {
         return BalloonReaction.builder()
                 .balloon(balloon)
                 .user(user)
-                .type(type);
+                .type(DEFAULT_BALLOON_REACTION_TYPE);
     }
 }

--- a/backend/src/test/java/com/musicinaballoon/fixture/ReactionNotificationFixture.java
+++ b/backend/src/test/java/com/musicinaballoon/fixture/ReactionNotificationFixture.java
@@ -1,0 +1,15 @@
+package com.musicinaballoon.fixture;
+
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import com.musicinaballoon.notification.domain.ReactionNotification.ReactionNotificationBuilder;
+import com.musicinaballoon.user.domain.User;
+
+public final class ReactionNotificationFixture {
+
+    public static ReactionNotificationBuilder reactionNotificationBuilder(BalloonReaction balloonReaction, User receiver) {
+        return ReactionNotification.builder()
+                .balloonReaction(balloonReaction)
+                .receiver(receiver);
+    }
+}

--- a/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationFacadeTest.java
+++ b/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationFacadeTest.java
@@ -143,6 +143,7 @@ class ReactionNotificationFacadeTest {
 
         BalloonReaction balloonReaction = balloonReaction(receiver);
         ReactionNotification reactionNotification = reactionNotificationBuilder(balloonReaction, receiver).build();
+        reactionNotification.prePersist();
 
         SseEmitter mockedEmitter = mock(SseEmitter.class);
         given(sseEmitterService.existsEmitter(anyLong())).willReturn(true);

--- a/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationFacadeTest.java
+++ b/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationFacadeTest.java
@@ -1,0 +1,124 @@
+package com.musicinaballoon.notification.application;
+
+import static com.musicinaballoon.fixture.BalloonFixture.youtubeMusicBalloonBuilder;
+import static com.musicinaballoon.fixture.BalloonReactionFixture.balloonReactionBuilder;
+import static com.musicinaballoon.fixture.MusicFixture.youtubeMusicBuilder;
+import static com.musicinaballoon.fixture.ReactionNotificationFixture.reactionNotificationBuilder;
+import static com.musicinaballoon.fixture.UserFixture.userBuilder;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
+import static org.mockito.BDDMockito.then;
+
+import com.musicinaballoon.balloon.domain.Balloon;
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.music.domain.YoutubeMusic;
+import com.musicinaballoon.notification.application.response.ReactionNotificationResponse;
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import com.musicinaballoon.user.application.UserService;
+import com.musicinaballoon.user.domain.User;
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter.DataWithMediaType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class ReactionNotificationFacadeTest {
+
+    @InjectMocks
+    ReactionNotificationFacade reactionNotificationFacade;
+
+    @Mock
+    ReactionNotificationService reactionNotificationService;
+
+    @Mock
+    SseEmitterService sseEmitterService;
+
+    @Mock
+    UserService userService;
+
+    private static List<ReactionNotification> reactionNotifications() {
+        User user = userBuilder().build();
+        YoutubeMusic youtubeMusic = youtubeMusicBuilder().build();
+        Balloon balloon = youtubeMusicBalloonBuilder(youtubeMusic, user).build();
+        BalloonReaction balloonReaction = balloonReactionBuilder(balloon, user).build();
+        return List.of(reactionNotificationBuilder(balloonReaction, user).build(),
+                reactionNotificationBuilder(balloonReaction, user).build());
+    }
+
+    private static String toPublishedSse(SseEventBuilder sseEventBuilder) {
+        Set<DataWithMediaType> properties = sseEventBuilder.build();
+        return properties.stream()
+                .map(DataWithMediaType::getData)
+                .map(Object::toString)
+                .collect(Collectors.joining());
+    }
+
+    @Test
+    @DisplayName("subscribe 는 빈 lastEventId 를 받을 수 있다.")
+    void subscribe_InputsEmptyLastEventId() {
+        // given
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        given(sseEmitterService.createSseEmitter(anyLong())).willReturn(mockEmitter);
+
+        // when & then
+        reactionNotificationFacade.subscribe(1L, "");
+    }
+
+    @Test
+    @DisplayName("subscribe 는 lastEventId 를 밭으면 지난 리엑션 알림 이벤트들을 전송한다.")
+    void subscribe_InputsLastEventId_SendLostReactionNotificationEvents() throws IOException {
+        // given
+        SseEmitter mockEmitter = mock(SseEmitter.class);
+        List<ReactionNotification> reactionNotifications = reactionNotifications();
+
+        given(sseEmitterService.createSseEmitter(anyLong())).willReturn(mockEmitter);
+        given(reactionNotificationService.getLostNotifications(anyLong(), any(ZonedDateTime.class))).willReturn(
+                reactionNotifications);
+
+        // when
+        reactionNotificationFacade.subscribe(1L, "");
+
+        // then
+        ArgumentCaptor<SseEventBuilder> argumentCaptor = ArgumentCaptor.forClass(SseEventBuilder.class);
+        then(mockEmitter).should().send(argumentCaptor.capture());
+        List<SseEventBuilder> captured = argumentCaptor.getAllValues();
+
+        // verify the content of the SSE
+        List<String> publishedSeeList =
+                captured.subList(1, captured.size()).stream().map(ReactionNotificationFacadeTest::toPublishedSse)
+                        .toList();
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(reactionNotifications.size()).isEqualTo(publishedSeeList.size());
+
+            for (int i = 0; i < reactionNotifications.size(); i++) {
+                final ReactionNotification reactionNotification = reactionNotifications.get(i);
+                final String publishedSse = publishedSeeList.get(i);
+
+                String[] eventOutputs = publishedSse.split("\n");
+                softly.assertThat(eventOutputs[0]).startsWith("id: " + reactionNotification.getCreatedAt().toString());
+                softly.assertThat(eventOutputs[1]).isEqualTo("event: Reaction-Notification");
+                softly.assertThat(eventOutputs[2]).isEqualTo("data:" + ReactionNotificationResponse.from(reactionNotification));
+            }
+        });
+    }
+
+    @Test
+    void sendNotification() {
+        // TODO
+    }
+}

--- a/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationFacadeTest.java
+++ b/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationFacadeTest.java
@@ -139,6 +139,8 @@ class ReactionNotificationFacadeTest {
     void sendNotification_SseEmitterSubscribed_SendNotificationEvent() throws IOException {
         // given
         User receiver = receiver();
+        given(userService.getUser(anyLong())).willReturn(receiver);
+
         BalloonReaction balloonReaction = balloonReaction(receiver);
         ReactionNotification reactionNotification = reactionNotificationBuilder(balloonReaction, receiver).build();
 
@@ -149,7 +151,7 @@ class ReactionNotificationFacadeTest {
                 reactionNotification);
 
         // when
-        reactionNotificationFacade.sendNotification(receiver, balloonReaction);
+        reactionNotificationFacade.sendNotification(1L, balloonReaction);
 
         // then
         ArgumentCaptor<SseEventBuilder> argumentCaptor = ArgumentCaptor.forClass(SseEventBuilder.class);
@@ -168,11 +170,12 @@ class ReactionNotificationFacadeTest {
         BalloonReaction balloonReaction = balloonReaction(receiver);
         ReactionNotification reactionNotification = reactionNotificationBuilder(balloonReaction, receiver).build();
 
+        given(userService.getUser(anyLong())).willReturn(receiver);
         given(sseEmitterService.existsEmitter(anyLong())).willReturn(false);
         given(reactionNotificationService.createReactionNotification(any(User.class), any(BalloonReaction.class))).willReturn(
                 reactionNotification);
 
         // when & then
-        reactionNotificationFacade.sendNotification(receiver, balloonReaction);
+        reactionNotificationFacade.sendNotification(1L, balloonReaction);
     }
 }

--- a/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationServiceTest.java
+++ b/backend/src/test/java/com/musicinaballoon/notification/application/ReactionNotificationServiceTest.java
@@ -1,0 +1,83 @@
+package com.musicinaballoon.notification.application;
+
+import static com.musicinaballoon.fixture.BalloonFixture.youtubeMusicBalloonBuilder;
+import static com.musicinaballoon.fixture.BalloonReactionFixture.balloonReactionBuilder;
+import static com.musicinaballoon.fixture.MusicFixture.youtubeMusicBuilder;
+import static com.musicinaballoon.fixture.ReactionNotificationFixture.reactionNotificationBuilder;
+import static com.musicinaballoon.fixture.UserFixture.userBuilder;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.musicinaballoon.balloon.domain.Balloon;
+import com.musicinaballoon.balloon.domain.BalloonReaction;
+import com.musicinaballoon.music.domain.YoutubeMusic;
+import com.musicinaballoon.notification.domain.ReactionNotification;
+import com.musicinaballoon.notification.repository.ReactionNotificationRepository;
+import com.musicinaballoon.user.domain.User;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReactionNotificationServiceTest {
+
+    @InjectMocks
+    ReactionNotificationService reactionNotificationService;
+
+    @Mock
+    ReactionNotificationRepository reactionNotificationRepository;
+
+    private static BalloonReaction balloonReaction(User receiver) {
+        YoutubeMusic youtubeMusic = youtubeMusicBuilder().build();
+        Balloon balloon = youtubeMusicBalloonBuilder(youtubeMusic, receiver).build();
+        BalloonReaction balloonReaction = balloonReactionBuilder(balloon, receiver).build();
+        return balloonReaction;
+    }
+
+    @Test
+    @DisplayName("createReactionNotification 은 유효한 입력을 받으면 ReactionNotification 을 반환한다.")
+    void createReactionNotification_InputsValid_ReturnsReactionNotification() {
+        // given
+        User receiver = userBuilder().build();
+        BalloonReaction balloonReaction = balloonReaction(receiver);
+        given(reactionNotificationRepository.save(any(ReactionNotification.class))).will(returnsFirstArg());
+
+        // when
+        ReactionNotification created = reactionNotificationService.createReactionNotification(receiver,
+                balloonReaction);
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(created.getBalloonReaction()).isEqualTo(balloonReaction);
+            softly.assertThat(created.getReceiver()).isEqualTo(receiver);
+        });
+    }
+
+    @Test
+    @DisplayName("getLostNotifications 은 유효한 입력을 받으면 ReactionNotification 들을 반환한다.")
+    void getLostNotifications_InputsValid_ReturnsReactionNotifications() {
+        // given
+        User receiver = userBuilder().build();
+        List<ReactionNotification> reactionNotifications = List.of(
+                reactionNotificationBuilder(balloonReaction(receiver), receiver).build(),
+                reactionNotificationBuilder(balloonReaction(receiver), receiver).build());
+        given(reactionNotificationRepository.findByReceiverIdAndCreatedAtGreaterThanOrderByCreatedAtAsc(anyLong(), any(
+                ZonedDateTime.class))).willReturn(reactionNotifications);
+
+        // when
+        List<ReactionNotification> gotten = reactionNotificationService.getLostNotifications(1L, ZonedDateTime.now());
+
+        // then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(gotten).isEqualTo(reactionNotifications);
+        });
+    }
+}

--- a/backend/src/test/java/com/musicinaballoon/notification/application/SseEmitterServiceTest.java
+++ b/backend/src/test/java/com/musicinaballoon/notification/application/SseEmitterServiceTest.java
@@ -1,0 +1,39 @@
+package com.musicinaballoon.notification.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.returnsSecondArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.musicinaballoon.notification.repository.EmitterRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class SseEmitterServiceTest {
+
+    @InjectMocks
+    SseEmitterService sseEmitterService;
+
+    @Mock
+    EmitterRepository emitterRepository;
+
+    @Test
+    @DisplayName("createSseEmitter 는 유효한 입력을 받으면 SseEmitter 를 반환한다.")
+    void createSseEmitter_InputsValid_ReturnsSseEmitter() {
+        // given
+        given(emitterRepository.save(anyLong(), any(SseEmitter.class))).will(returnsSecondArg());
+
+        // when
+        SseEmitter sseEmitter = sseEmitterService.createSseEmitter(1L);
+
+        // then
+        assertThat(sseEmitter).isNotNull();
+    }
+}


### PR DESCRIPTION
## 변경사항
- GET /notification/reaction/subscribe 가 추가되었습니다. 이는 리엑션 알림을 구독하고 SseEmitter를 응답합니다.
- 풍선에 리엑션을 할때 구독된 emitter에 알림 이벤트를 전송합니다.