### PR TITLE
fix: [FRONT] 알림 관련 오류 수정

### DIFF
--- a/frontend/src/api/notification/subscribeReactionNotification.ts
+++ b/frontend/src/api/notification/subscribeReactionNotification.ts
@@ -1,7 +1,7 @@
-import { END_POINTS } from '@constant/api';
+import { BASE_URL, END_POINTS } from '@constant/api';
 
 export const subscribeReactionNotification = () => {
-  const eventSource = new EventSource(END_POINTS.REACTION_NOTIFICATION_SUBSCRIBE, {
+  const eventSource = new EventSource(BASE_URL + END_POINTS.REACTION_NOTIFICATION_SUBSCRIBE, {
     withCredentials: true,
   });
 

--- a/frontend/src/component/balloon/BalloonInfoModal/BalloonInfoModal.tsx
+++ b/frontend/src/component/balloon/BalloonInfoModal/BalloonInfoModal.tsx
@@ -120,7 +120,7 @@ const BalloonInfoModal = ({ isOpen = true, onClose }: BalloonInfoModalProps) => 
         <Flex css={bottomContainerStyling}>
           <ReactionSelector selectedKey={selectedReactionKey} onSelect={onReact} />
           <Text css={creatorNameStyling} size="small">
-            From. username
+            From. {balloonData.creator.name}
           </Text>
         </Flex>
       </Flex>

--- a/frontend/src/component/balloon/BalloonInfoModal/BalloonInfoModal.tsx
+++ b/frontend/src/component/balloon/BalloonInfoModal/BalloonInfoModal.tsx
@@ -44,6 +44,10 @@ const BalloonInfoModal = ({ isOpen = true, onClose }: BalloonInfoModalProps) => 
   const jsConfetti = new JSConfetti({ canvas: confettiCanvas as unknown as HTMLCanvasElement });
 
   const onReact = (reactionKey: ReactionKeyType | null) => {
+    if (selectedReactionKey === reactionKey) {
+      return;
+    }
+
     if (reactionKey) {
       reactBalloonMutation.mutate(
         { balloonId, data: { balloonReactionType: reactionKey } },

--- a/frontend/src/component/common/BalloonMap/BalloonMap.tsx
+++ b/frontend/src/component/common/BalloonMap/BalloonMap.tsx
@@ -65,7 +65,7 @@ const BalloonMap = ({ centerLat, centerLon, balloons, wave }: BalloonMapProps) =
       ref={mapRef}
       center={[centerLat, centerLon]}
       zoom={MAP_INITIAL_ZOOM_SIZE}
-      style={{ height: '100vh' }}
+      style={{ height: '100dvh' }}
       maxZoom={MAP_MAX_ZOOM_SIZE}
       minZoom={MAP_MIN_ZOOM_SIZE}
       zoomControl={false}

--- a/frontend/src/component/layout/Header/Notifications/Notifications.tsx
+++ b/frontend/src/component/layout/Header/Notifications/Notifications.tsx
@@ -28,6 +28,10 @@ const Notifications = () => {
   );
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (reactionNofitications.length === 0) {
+      return;
+    }
+
     setAnchorEl(event.currentTarget);
   };
 

--- a/frontend/src/component/layout/Header/Notifications/Notifications.tsx
+++ b/frontend/src/component/layout/Header/Notifications/Notifications.tsx
@@ -15,6 +15,7 @@ import { useSetRecoilState } from 'recoil';
 
 import { subscribeReactionNotification } from '@/api/notification/subscribeReactionNotification';
 import { selectedBalloonIdState } from '@/store/balloon';
+import { zIndex } from '@/style/Theme';
 import type { ReactionNotificationData } from '@/type/notification';
 import { createBalloonIconImage } from '@/util/balloon';
 import { reactionKeyTypeToEmoji } from '@/util/reaction';
@@ -70,6 +71,7 @@ const Notifications = () => {
           vertical: 'top',
           horizontal: 'right',
         }}
+        sx={{ zIndex: zIndex.overlayTop }}
       >
         <List sx={{ width: '100%', maxWidth: 360, maxHeight: 250, bgcolor: 'background.paper' }}>
           {reactionNofitications.map((notification) => (

--- a/frontend/src/component/layout/Header/Notifications/Notifications.tsx
+++ b/frontend/src/component/layout/Header/Notifications/Notifications.tsx
@@ -17,6 +17,7 @@ import { subscribeReactionNotification } from '@/api/notification/subscribeReact
 import { selectedBalloonIdState } from '@/store/balloon';
 import type { ReactionNotificationData } from '@/type/notification';
 import { createBalloonIconImage } from '@/util/balloon';
+import { reactionKeyTypeToEmoji } from '@/util/reaction';
 
 const Notifications = () => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
@@ -88,11 +89,13 @@ const Notifications = () => {
                     setSelectedBalloonId(notification.balloon.id);
                   }}
                 >
-                  <Avatar sx={{ bgcolor: grey[300] }}>👍</Avatar>
+                  <Avatar sx={{ bgcolor: grey[300] }}>
+                    {reactionKeyTypeToEmoji(notification.reactionType)}
+                  </Avatar>
                 </Badge>
               </ListItemAvatar>
               <ListItemText
-                primary={`${notification.responder.name} gave a 👍`}
+                primary={`${notification.responder.name} gave a ${reactionKeyTypeToEmoji(notification.reactionType)}`}
                 secondary={`to ${notification.balloon.title} balloon`}
               />
             </ListItem>

--- a/frontend/src/util/reaction.ts
+++ b/frontend/src/util/reaction.ts
@@ -1,0 +1,19 @@
+import type { ReactionKeyType } from '@/type/reaction';
+
+export function reactionKeyTypeToEmoji(reaction: ReactionKeyType) {
+  switch (reaction) {
+    case 'BALLOON':
+      return '🎈';
+    case 'EYES':
+      return '👀';
+    case 'HEART':
+      return '❤️';
+    case 'SMILE':
+      return '😄';
+    case 'THUMBS_DOWN':
+      return '👎';
+    case 'THUMBS_UP':
+    default:
+      return '👍';
+  }
+}


### PR DESCRIPTION
## 변경사항
- 알림이 없으면 눌러도 화면에 표시되지 않습니다.
- 알림에서 어떤 반응을 보였는지 보입니다.
- 모바일을 위한 화면 크기를 조절했습니다.
- 반응을 여러번 전송하는 오류를 수정했습니다.
- 알림 창을 모달 뒤로 숨겼습니다.
- 풍선에 만든이를 표시합니다.